### PR TITLE
Update WCNSS_qcom_cfg.ini

### DIFF
--- a/rootdir/system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
+++ b/rootdir/system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
@@ -24,7 +24,7 @@ gEnableBmps=1
 
 # 1: Enable standby, 2: Enable Deep sleep, 3: Enable Mcast/Bcast Filter
 
-gEnableSuspend=3
+gEnableSuspend=2
 
 
 # Phy Mode (auto, b, g, n, etc)
@@ -391,7 +391,7 @@ gScanAgingTime=0
 #Enable Power saving mechanism Based on Android Framework
 #If set to 0 Driver internally control the Power saving mechanism
 #If set to 1 Android Framwrok control the Power saving mechanism
-isAndroidPsEn=0
+isAndroidPsEn=1
 
 #disable LDPC in STA mode if the AP is TXBF capable
 gDisableLDPCWithTxbfAP=1


### PR DESCRIPTION
This takes care of 2 issues in rhine devices:  wifi disconnect after about 15 minutes of sleep; and excessive battery draining due to a barrage of arp packets causing constant wakelocks. For more detail, see here:  http://forum.xda-developers.com/showpost.php?p=62070656&postcount=117

I have tested this for a half of the day and there is no wifi disconnect and a pretty good deep sleep.
