### PR TITLE
Enabling Manual Brightness in TWRP 2.8.7

### DIFF
--- a/BoardConfigCommon.mk
+++ b/BoardConfigCommon.mk
@@ -105,7 +105,7 @@ TW_CRYPTO_FS_FLAGS := "0x00000406"
 TW_CRYPTO_KEY_LOC := "footer"
 TW_INCLUDE_FUSE_EXFAT := true
 TW_BRIGHTNESS_PATH := /sys/class/leds/wled:backlight/brightness
-TW_MAX_BRIGHTNESS := 4095
+TW_MAX_BRIGHTNESS := 255
 TW_NO_USB_STORAGE := true
 
 # Releasetools

--- a/rootdir/system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
+++ b/rootdir/system/etc/firmware/wlan/prima/WCNSS_qcom_cfg.ini
@@ -24,7 +24,7 @@ gEnableBmps=1
 
 # 1: Enable standby, 2: Enable Deep sleep, 3: Enable Mcast/Bcast Filter
 
-gEnableSuspend=3
+gEnableSuspend=2
 
 
 # Phy Mode (auto, b, g, n, etc)
@@ -391,7 +391,7 @@ gScanAgingTime=0
 #Enable Power saving mechanism Based on Android Framework
 #If set to 0 Driver internally control the Power saving mechanism
 #If set to 1 Android Framwrok control the Power saving mechanism
-isAndroidPsEn=0
+isAndroidPsEn=1
 
 #disable LDPC in STA mode if the AP is TXBF capable
 gDisableLDPCWithTxbfAP=1


### PR DESCRIPTION
Due to a wrong value, manual brightness wouldn't work and excessive backlight would cause temperature to rise to over 65 degrees during backup/restore operations.  Fixed. Tested on Xperia Z1.
